### PR TITLE
chore: clean up dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,26 +5,22 @@
 
 version: 2
 updates:
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: /
     schedule:
       interval: daily
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
 
-  - package-ecosystem: npm
-    directory: /apps/blog
+  - package-ecosystem: bun
+    directory: /packages/remark-plugin
     schedule:
       interval: daily
 
-  - package-ecosystem: npm
-    directory: /packages/tailwind
-    schedule:
-      interval: daily
-
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: /apps/website
     schedule:
       interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: bun
+  - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
@@ -15,12 +15,12 @@ updates:
     schedule:
       interval: daily
 
-  - package-ecosystem: bun
+  - package-ecosystem: npm
     directory: /packages/remark-plugin
     schedule:
       interval: daily
 
-  - package-ecosystem: bun
+  - package-ecosystem: npm
     directory: /apps/website
     schedule:
       interval: daily


### PR DESCRIPTION
Since we use bun as a package engine, change the dependabot package ecosystem to also be bun